### PR TITLE
feat: improve <AfterDraf>

### DIFF
--- a/src/AfterDraf/__tests__/createSingleRunDraf.server.test.tsx
+++ b/src/AfterDraf/__tests__/createSingleRunDraf.server.test.tsx
@@ -1,0 +1,3 @@
+/** @jest-environment node */
+
+require('./createSingleRunDraf.test');

--- a/src/AfterDraf/__tests__/createSingleRunDraf.test.tsx
+++ b/src/AfterDraf/__tests__/createSingleRunDraf.test.tsx
@@ -1,16 +1,21 @@
 import {createElement as h} from 'react';
 import {shallow} from 'enzyme';
-import {AfterDraf} from '..';
+import createSingleRunDraf from '../createSingleRunDraf';
 
 const isClient = typeof window === 'object';
 const sleep = (time) => new Promise((resolve) => setTimeout(resolve, time));
 
-describe('<AfterDraf>', () => {
-  it('default <AfterDraf> exists', () => {
+describe('createSingleRunDraf()', () => {
+  it('factory works', () => {
+    expect(typeof createSingleRunDraf).toBe('function');
+
+    const AfterDraf = createSingleRunDraf();
+
     expect(typeof AfterDraf).toBe('function');
   });
 
   it('waits for DRAF on client before rendering', async () => {
+    const AfterDraf = createSingleRunDraf();
     const wrapper = shallow(
       <AfterDraf>
         <div>foobar</div>
@@ -30,7 +35,8 @@ describe('<AfterDraf>', () => {
     expect(wrapper.html()).toBe('<div>foobar</div>');
   });
 
-  it('waits for DRAF every mount', async () => {
+  it('does not wait for DRAF for the second time', async () => {
+    const AfterDraf = createSingleRunDraf();
     const wrapper = shallow(
       <AfterDraf>
         <div>foobar</div>
@@ -39,6 +45,10 @@ describe('<AfterDraf>', () => {
 
     await sleep(100);
 
+    wrapper.update();
+
+    expect(wrapper.html()).toBe('<div>foobar</div>');
+
     const wrapper2 = shallow(
       <AfterDraf>
         <div>bazooka</div>
@@ -46,15 +56,9 @@ describe('<AfterDraf>', () => {
     );
 
     if (isClient) {
-      expect(wrapper2.html()).toBe(null);
+      expect(wrapper.html()).toBe('<div>foobar</div>');
     } else {
-      expect(wrapper2.html()).toBe('<div>bazooka</div>');
+      expect(wrapper.html()).toBe('<div>foobar</div>');
     }
-
-    await sleep(100);
-
-    wrapper2.update();
-
-    expect(wrapper2.html()).toBe('<div>bazooka</div>');
   });
 });

--- a/src/AfterDraf/__tests__/index.server.test.tsx
+++ b/src/AfterDraf/__tests__/index.server.test.tsx
@@ -1,0 +1,3 @@
+/** @jest-environment node */
+
+require('./index.test');

--- a/src/AfterDraf/__tests__/index.test.tsx
+++ b/src/AfterDraf/__tests__/index.test.tsx
@@ -1,0 +1,35 @@
+import {createElement as h} from 'react';
+import {shallow} from 'enzyme';
+import {createAfterDraf, AfterDraf} from '..';
+
+const sleep = (time) => new Promise((resolve) => setTimeout(resolve, time));
+
+describe('<AfterDraf>', () => {
+  it('factory works', () => {
+    expect(typeof createAfterDraf).toBe('function');
+
+    const AfterDraf = createAfterDraf();
+
+    expect(typeof AfterDraf).toBe('function');
+  });
+
+  it('default <AfterDraf> exists', () => {
+    expect(typeof AfterDraf).toBe('function');
+  });
+
+  it('waits for DRAF on client before rendering', async () => {
+    const wrapper = shallow(
+      <AfterDraf>
+        <div>foobar</div>
+      </AfterDraf>
+    );
+
+    expect(wrapper.html()).toBe(null);
+
+    await sleep(100);
+
+    wrapper.update();
+
+    expect(wrapper.html()).toBe('<div>foobar</div>');
+  });
+});

--- a/src/AfterDraf/__tests__/index.test.tsx
+++ b/src/AfterDraf/__tests__/index.test.tsx
@@ -2,6 +2,7 @@ import {createElement as h} from 'react';
 import {shallow} from 'enzyme';
 import {createAfterDraf, AfterDraf} from '..';
 
+const isClient = typeof window === 'object';
 const sleep = (time) => new Promise((resolve) => setTimeout(resolve, time));
 
 describe('<AfterDraf>', () => {
@@ -24,7 +25,11 @@ describe('<AfterDraf>', () => {
       </AfterDraf>
     );
 
-    expect(wrapper.html()).toBe(null);
+    if (isClient) {
+      expect(wrapper.html()).toBe(null);
+    } else {
+      expect(wrapper.html()).toBe('<div>foobar</div>');
+    }
 
     await sleep(100);
 

--- a/src/AfterDraf/createSingleRunDraf.ts
+++ b/src/AfterDraf/createSingleRunDraf.ts
@@ -7,7 +7,7 @@ export interface IAfterDrafState {
 
 export const createSingleRunDraf = isClient
   ? () => {
-    let done = false;
+    let signelDrafFinished = false;
 
     return class extends Component<{}, IAfterDrafState> {
       frame;
@@ -16,7 +16,7 @@ export const createSingleRunDraf = isClient
       constructor (props, context) {
         super(props, context);
 
-        if (isClient && !done) {
+        if (isClient && !signelDrafFinished) {
           this.state = {
             ready: false
           };
@@ -24,12 +24,12 @@ export const createSingleRunDraf = isClient
       }
 
       componentDidMount () {
-        if (!done) {
+        if (!signelDrafFinished) {
           const RAF = requestAnimationFrame;
 
           this.frame = RAF(() => {
             this.frame = RAF(() => {
-              done = true;
+              signelDrafFinished = true;
               this.setState({ready: true});
             });
           });
@@ -43,7 +43,7 @@ export const createSingleRunDraf = isClient
       }
 
       render () {
-        if (!isClient || done) {
+        if (!isClient || signelDrafFinished) {
           return this.props.children;
         }
 

--- a/src/AfterDraf/createSingleRunDraf.ts
+++ b/src/AfterDraf/createSingleRunDraf.ts
@@ -1,0 +1,56 @@
+import {Component} from 'react';
+import {isClient} from '../util';
+
+export interface IAfterDrafState {
+  ready: boolean;
+}
+
+export const createSingleRunDraf = isClient
+  ? () => {
+    let done = false;
+
+    return class extends Component<{}, IAfterDrafState> {
+      frame;
+      state: IAfterDrafState;
+
+      constructor (props, context) {
+        super(props, context);
+
+        if (isClient && !done) {
+          this.state = {
+            ready: false
+          };
+        }
+      }
+
+      componentDidMount () {
+        if (!done) {
+          const RAF = requestAnimationFrame;
+
+          this.frame = RAF(() => {
+            this.frame = RAF(() => {
+              done = true;
+              this.setState({ready: true});
+            });
+          });
+        }
+      }
+
+      componentWillUnmount () {
+        if (this.frame) {
+          cancelAnimationFrame(this.frame);
+        }
+      }
+
+      render () {
+        if (!isClient || done) {
+          return this.props.children;
+        }
+
+        return this.state.ready ? this.props.children : null;
+      }
+    }
+  }
+  : () => (props) => props.children;
+
+export default createSingleRunDraf;

--- a/src/AfterDraf/index.ts
+++ b/src/AfterDraf/index.ts
@@ -5,19 +5,15 @@ export interface IAfterDrafState {
   ready: boolean;
 }
 
-const Passthrough = (props) => props.children;
-
-export const createAfterDraf = (times = 1) => {
-  let cnt = 0;
-
-  return class extends Component<{}, IAfterDrafState> {
+export const AfterDraf = isClient
+  ? class AfterDraf extends Component<{}, IAfterDrafState> {
     frame;
     state: IAfterDrafState;
 
     constructor (props, context) {
       super(props, context);
 
-      if (isClient && cnt < times) {
+      if (isClient) {
         this.state = {
           ready: false
         };
@@ -25,32 +21,21 @@ export const createAfterDraf = (times = 1) => {
     }
 
     componentDidMount () {
-      if (cnt < times) {
-        const RAF = requestAnimationFrame;
+      const RAF = requestAnimationFrame;
 
+      this.frame = RAF(() => {
         this.frame = RAF(() => {
-          this.frame = RAF(() => {
-            cnt++;
-            this.setState({ready: true});
-          });
+          this.setState({ready: true});
         });
-      }
+      });
     }
 
     componentWillUnmount () {
-      if (cnt < times) {
-        cancelAnimationFrame(this.frame);
-      }
+      cancelAnimationFrame(this.frame);
     }
 
     render () {
-      if (!isClient || cnt >= times) {
-        return this.props.children;
-      }
-
       return this.state.ready ? this.props.children : null;
-    }
+    };
   }
-};
-
-export const AfterDraf = isClient ? createAfterDraf(Infinity) : Passthrough;
+  : (props) => props.children;

--- a/src/AfterDraf/index.ts
+++ b/src/AfterDraf/index.ts
@@ -25,7 +25,7 @@ export const createAfterDraf = (times = 1) => {
     }
 
     componentDidMount () {
-      if (isClient && cnt < times) {
+      if (cnt < times) {
         const RAF = requestAnimationFrame;
 
         this.frame = RAF(() => {
@@ -38,7 +38,7 @@ export const createAfterDraf = (times = 1) => {
     }
 
     componentWillUnmount () {
-      if (isClient && cnt < times) {
+      if (cnt < times) {
         cancelAnimationFrame(this.frame);
       }
     }

--- a/src/AfterDraf/index.ts
+++ b/src/AfterDraf/index.ts
@@ -1,31 +1,56 @@
 import {Component} from 'react';
-
-const RAF = requestAnimationFrame;
+import {isClient} from '../util';
 
 export interface IAfterDrafState {
   ready: boolean;
 }
 
-export class AfterDraf extends Component<{}, IAfterDrafState> {
-  frame;
+const Passthrough = (props) => props.children;
 
-  state: IAfterDrafState = {
-    ready: false
-  };
+export const createAfterDraf = (times = 1) => {
+  let cnt = 0;
 
-  componentDidMount () {
-    this.frame = RAF(() => {
-      this.frame = RAF(() => {
-        this.setState({ready: true});
-      });
-    });
+  return class extends Component<{}, IAfterDrafState> {
+    frame;
+    state: IAfterDrafState;
+
+    constructor (props, context) {
+      super(props, context);
+
+      if (isClient && cnt < times) {
+        this.state = {
+          ready: false
+        };
+      }
+    }
+
+    componentDidMount () {
+      if (isClient && cnt < times) {
+        const RAF = requestAnimationFrame;
+
+        this.frame = RAF(() => {
+          this.frame = RAF(() => {
+            cnt++;
+            this.setState({ready: true});
+          });
+        });
+      }
+    }
+
+    componentWillUnmount () {
+      if (isClient && cnt < times) {
+        cancelAnimationFrame(this.frame);
+      }
+    }
+
+    render () {
+      if (!isClient || cnt >= times) {
+        return this.props.children;
+      }
+
+      return this.state.ready ? this.props.children : null;
+    }
   }
+};
 
-  componentWillUnmount () {
-    cancelAnimationFrame(this.frame);
-  }
-
-  render () {
-    return this.state.ready ? this.props.children : null;
-  }
-}
+export const AfterDraf = isClient ? createAfterDraf(Infinity) : Passthrough;

--- a/src/__tests__/setup.js
+++ b/src/__tests__/setup.js
@@ -5,4 +5,6 @@ configure({
   adapter: new Adapter()
 });
 
-global.requestAnimationFrame = window.requestAnimationFrame = (callback) => setTimeout(callback, 17);
+if (typeof window === 'object') {
+  global.requestAnimationFrame = window.requestAnimationFrame = (callback) => setTimeout(callback, 17);
+}


### PR DESCRIPTION
Make `<AfterDraf>` work on server. As well as allow users to create their
custom `<AfterDraf>`s, which wait for DRAF only a given number of times,
for example, to prevent FOUC, your component needs to wait for DRAF only
for the first time but subsequent re-renders can render children
synchronously.